### PR TITLE
Add qFit-at-scale article from The Stacks to Publications

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -30,6 +30,11 @@ James S. Fraser, Henry van den Bedem. *The Stacks*, 2026.
 James Holton, Stephanie A. Wankowicz. *The Stacks*, 2026.  
 [Read the article](https://doi.org/10.82153/2me0-hd96){: .btn .btn--primary}
 
+**Recovering Conformational Heterogeneity from the Protein Data 
+Bank at Scale**  
+Stephanie A. Wankowicz. *The Stacks*, 2026.  
+[Read the article](https://doi.org/10.82153/pff0-ck46){: .btn .btn--primary}
+
 ## Our Open Science Resources
 
 **The DiffUSE Logbook** -- A real-time research notebook 


### PR DESCRIPTION
Adds the qFit-at-scale entry to the Scholarly Work section of the Publications page, matching the format of the two existing Stacks entries.